### PR TITLE
Add ? to Question and drop additional whitespace

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,9 @@
     />
 
     <style>
+      a {
+        display: inline-block;
+      }
       h1,
       h2,
       h3 {
@@ -368,7 +371,7 @@
       >
         Remote Ruby
       </a>
-      podcast.
+      podcast?
     </div>
   </body>
 </html>


### PR DESCRIPTION
Problem:
Noticed at the bottom of the page there is some additional whitespace after the link and the question doesn't end in a question mark.

Solution:
Added a question mark and added a style for displaying anchors as inline-block which removes whitespaces from underlines.